### PR TITLE
Add Support for Custom TwoWire Objects (Multiple I2C Buses)

### DIFF
--- a/BME280_LITE.cpp
+++ b/BME280_LITE.cpp
@@ -4,17 +4,17 @@ BME_RegisterData BME280_LITE::read(uint8_t BMEaddress, uint8_t BMEregAddress, ui
   BME_RegisterData status = {false, {0}};
 
   #if defined(WIRE_HAS_TIMEOUT)
-    Wire.setWireTimeout(10000, true);
+    _wire->setWireTimeout(10000, true);
   #endif
 
-  Wire.beginTransmission(BMEaddress);
-  Wire.write(BMEregAddress);
-  if (Wire.endTransmission(false) != 0) return status;
+  _wire->beginTransmission(BMEaddress);
+  _wire->write(BMEregAddress);
+  if (_wire->endTransmission(false) != 0) return status;
 
-  if (Wire.requestFrom(BMEaddress, BMEnumBytes, true) != BMEnumBytes) return status;
+  if (_wire->requestFrom(BMEaddress, BMEnumBytes, true) != BMEnumBytes) return status;
 
   for (uint8_t i = 0; i<BMEnumBytes; i++) {
-    status.data[i] = Wire.read();
+    status.data[i] = _wire->read();
   }
   status.isValid = true;
   return status;
@@ -22,18 +22,18 @@ BME_RegisterData BME280_LITE::read(uint8_t BMEaddress, uint8_t BMEregAddress, ui
 
 bool BME280_LITE::write(uint8_t BMEaddress, uint8_t BMEregAddress, uint8_t BMEwriteData) {
   #if defined(WIRE_HAS_TIMEOUT)
-    Wire.setWireTimeout(10000, true);
+    _wire->setWireTimeout(10000, true);
   #endif
 
-  Wire.beginTransmission(BMEaddress);
-  Wire.write(BMEregAddress);
-  Wire.write(BMEwriteData);
-  if (Wire.endTransmission() != 0) return false;
+  _wire->beginTransmission(BMEaddress);
+  _wire->write(BMEregAddress);
+  _wire->write(BMEwriteData);
+  if (_wire->endTransmission() != 0) return false;
   return true; 
 }
 
-bool BME280_LITE::begin(uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR) {
-  Wire.begin();
+bool BME280_LITE::begin(TwoWire *w,uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR) {
+  _wire = w;
 
   if (write(BMEaddress, CTRL_HUM, BMEosrs_H) && 
       write(BMEaddress, CTRL_MEAS, (BMEosrs_T << 5) | (BMEosrs_P << 2) | BMEmode) &&

--- a/BME280_LITE.cpp
+++ b/BME280_LITE.cpp
@@ -43,6 +43,11 @@ bool BME280_LITE::begin(TwoWire *w,uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_
   return false;
 }
 
+bool BME280_LITE::begin(uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR) {
+  Wire.begin();
+  return begin(&Wire, BMEaddress, BMEosrs_H, BMEosrs_T, BMEosrs_P, BMEmode, BMEstby, BMEIIR);
+}
+
 bool BME280_LITE::calibrate(uint8_t BMEaddress) {
   BME_RegisterData Calib1 = read(BMEaddress, DIG_T1_LSB, 26);
   if (!Calib1.isValid) return false;

--- a/BME280_LITE.h
+++ b/BME280_LITE.h
@@ -76,6 +76,7 @@ struct BME_SensorData {
 class BME280_LITE {
   public:
     bool begin(TwoWire *w, uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR);
+    bool begin(uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR);
     bool calibrate(uint8_t BMEaddress);
     BME_SensorData readTemperature(uint8_t BMEaddress);
     BME_SensorData readPressure(uint8_t BMEaddress);

--- a/BME280_LITE.h
+++ b/BME280_LITE.h
@@ -75,7 +75,7 @@ struct BME_SensorData {
 
 class BME280_LITE {
   public:
-    bool begin(uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR);
+    bool begin(TwoWire *w, uint8_t BMEaddress, uint8_t BMEosrs_H, uint8_t BMEosrs_T, uint8_t BMEosrs_P, uint8_t BMEmode, uint8_t BMEstby, uint8_t BMEIIR);
     bool calibrate(uint8_t BMEaddress);
     BME_SensorData readTemperature(uint8_t BMEaddress);
     BME_SensorData readPressure(uint8_t BMEaddress);
@@ -86,6 +86,7 @@ class BME280_LITE {
     BME_RegisterData read(uint8_t BMEaddress, uint8_t BMEregAddress, uint8_t BMEnumBytes);
     bool write(uint8_t BMEaddress, uint8_t BMEregAddress, uint8_t BMEwriteData);
 
+    TwoWire *_wire;
     uint16_t T1;
     int16_t T2, T3;
     uint16_t P1;

--- a/README.md
+++ b/README.md
@@ -29,14 +29,25 @@ The initialization function configures some settings like:
 
 > **Note**: Higher oversampling settings take more time but are still quite fast (under 10ms)
 
-#### Parameters
+#### Two Ways to Initialize
 
+**Option 1: Default (backwards compatible)**
 ```cpp
 bme.begin(BMEaddress, Humidity_oversampling, Temperature_oversampling, Pressure_oversampling, BME_mode, BME_standby, BME_IIR_filter)
 ```
+Uses the default `Wire` object and automatically calls `Wire.begin()`.
+
+**Option 2: Custom I2C Bus (for custom pins or multiple I2C buses)**
+```cpp
+bme.begin(&Wire, BMEaddress, Humidity_oversampling, Temperature_oversampling, Pressure_oversampling, BME_mode, BME_standby, BME_IIR_filter)
+```
+Allows you to specify a custom `TwoWire` object (e.g., `&Wire`, `&Wire1`) and initialize it yourself with custom pins.
+
+#### Parameters
 
 | Parameter | Values | Description |
 |-----------|--------|-------------|
+| `TwoWire*` (optional) | `&Wire`, `&Wire1`, etc. | I²C bus object pointer (optional, defaults to Wire) |
 | `BMEaddress` | `0x76` (primary), `0x77` (alternate) | I²C device address |
 | `Humidity oversampling` | `BME_H_SKIP=0`, `BME_H_X1=1`, `BME_H_X2=2`, `BME_H_X4=3`, `BME_H_X8=4`, `BME_H_X16=5` | Humidity measurement oversampling |
 | `Temperature oversampling` | `BME_T_SKIP=0`, `BME_T_X1=1`, `BME_T_X2=2`, `BME_T_X4=3`, `BME_T_X8=4`, `BME_T_X16=5` | Temperature measurement oversampling |
@@ -47,9 +58,27 @@ bme.begin(BMEaddress, Humidity_oversampling, Temperature_oversampling, Pressure_
 
 **Returns**: `boolean` - `true` if initialization was successful, `false` otherwise
 
-**Example**:
+**Example (Default)**:
 ```cpp
-bme.begin(BME_ADDR, BME_H_X1, BME_T_X1, BME_P_X2, BME_NORMAL, BME_TSB_0_5MS, BME_FILTER_2);
+// Uses default Wire object
+if (!bme.begin(0x76, BME_H_X1, BME_T_X1, BME_P_X2, BME_NORMAL, BME_TSB_0_5MS, BME_FILTER_2)) {
+  Serial.println("BME280 initialization failed!");
+}
+```
+
+**Example (Custom I2C Pins - ESP32)**:
+```cpp
+// Define custom pins
+#define SDA_PIN 21
+#define SCL_PIN 22
+
+// Initialize Wire with custom pins before calling begin
+Wire.begin(SDA_PIN, SCL_PIN);
+
+// Pass &Wire to use the initialized bus
+if (!bme.begin(&Wire, 0x76, BME_H_X1, BME_T_X1, BME_P_X2, BME_NORMAL, BME_TSB_0_5MS, BME_FILTER_2)) {
+  Serial.println("BME280 initialization failed!");
+}
 ```
 
 ---

--- a/examples/BME280_LITE_TEST/BME280_LITE_TEST.ino
+++ b/examples/BME280_LITE_TEST/BME280_LITE_TEST.ino
@@ -2,7 +2,7 @@
   This is the test for the BME280_LITE library.
   This library only works with I2C. The device's address is 0x76 or 0x77.
   The objective of the library is to be as simple and as lightweight as possible.
-  Version = 2.0.0 (changes include more error handling by setting function output as structs)
+  Version = 2.1.0 (added support for custom TwoWire objects for multiple I2C buses)
   
   Written by Edward Sicoe.
 */
@@ -10,20 +10,50 @@
 #include <BME280_LITE.h>
 
 #define BME_ADDR    0x76 // Primary address (0x77 is the alternate)
-#define SEA_LEVEL_PRES  1017.8 // sea level pressure in hPa to use in the readAltitude funciton.
+#define SEA_LEVEL_PRES  1017.8 // sea level pressure in hPa to use in the readAltitude function.
 
 BME280_LITE bme;
 
 void setup() {
-  bme.begin(BME_ADDR, // returns a T/F based on initialization.
-            BME_H_X1, // All settings can be found in the docs.
-            BME_T_X1, 
-            BME_P_X16, 
-            BME_NORMAL, 
-            BME_TSB_0_5MS, 
-            BME_FILTER_2);
-  bme.calibrate(BME_ADDR); // returns T/F based on calibration status. You can read it if you wish.
   Serial.begin(9600);
+  
+  // Option 1: Use default Wire (backwards compatible)
+  if (!bme.begin(BME_ADDR, 
+                 BME_H_X1, 
+                 BME_T_X1, 
+                 BME_P_X16, 
+                 BME_NORMAL, 
+                 BME_TSB_0_5MS, 
+                 BME_FILTER_2)) {
+    Serial.println("BME280 initialization failed!");
+    while(1);
+  }
+  
+  /* Option 2: Use custom I2C pins (ESP32 example)
+  #define SDA_PIN 21
+  #define SCL_PIN 22
+  
+  Wire.begin(SDA_PIN, SCL_PIN);  // Initialize with custom pins
+  
+  if (!bme.begin(&Wire,          // Pass the Wire object
+                 BME_ADDR, 
+                 BME_H_X1, 
+                 BME_T_X1, 
+                 BME_P_X16, 
+                 BME_NORMAL, 
+                 BME_TSB_0_5MS, 
+                 BME_FILTER_2)) {
+    Serial.println("BME280 initialization failed!");
+    while(1);
+  }
+  */
+  
+  if (!bme.calibrate(BME_ADDR)) {
+    Serial.println("BME280 calibration failed!");
+    while(1);
+  }
+  
+  Serial.println("BME280 initialized successfully!");
 }
 
 void loop() {


### PR DESCRIPTION
adds support for using custom TwoWire objects while maintaining full backwards compatibility with existing code. This enables the library to work with multiple I2C buses and custom pin configurations (essential for ESP32/ESP8266 projects).